### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The library can be used with custom data. For example you could gather data for 
 
 Add this git URL in Unity's package manager.
 ```
-https://github.com/hk1ll3r/ReverseGeocoderForUnity
+https://github.com/hk1ll3r/ReverseGeocoderForUnity.git
 ```
 
 ### Install via Traditional .unitypackage File


### PR DESCRIPTION
Hi, Thank you for making this awesome repo.

But when I tried to install this package via Git URL, I faced an error so I tried to fix a minor docs update.

Fix unable to add package error on Unity Package Manager.

### Problem
When trying to add git from the 'Install via Git URL', it faced an error:

```
[Package Manager Window] Cannot perform upm operation: Unable to add package [https://github.com/hk1ll3r/ReverseGeocoderForUnity]:
  Package name 'https://github.com/hk1ll3r/ReverseGeocoderForUnity' is invalid. [InvalidParameter].
[Package Manager Window] Error adding package: https://github.com/hk1ll3r/ReverseGeocoderForUnity.
```

![add_extension_git](https://github.com/hk1ll3r/ReverseGeocoderForUnity/assets/1735681/b3429849-6d9e-4095-b7c3-ebf4b02b5078)


